### PR TITLE
Config support with two fiel

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ Flags:
       --user string                    The name of the kubeconfig user to use
 ```
 
+## Configuration
+
+The application uses a configuration file named `.conditioner.json` located in the user's home directory. This file is automatically created if it does not exist.
+
+The configuration file is in JSON format and contains the following fields:
+
+- `prepend-whoami`: A boolean value that indicates whether to prepend the user's identity to the output. Default value is `false`.
+- `allow-list`: An array of strings that represents a list of allowed entities for the application. Default value is an empty array `[]`.
+
+Here is an example of a configuration file:
+
+```json
+{
+  "prepend-whoami": false,
+  "allow-list": []
+}
+```
+
 
 ### Examples
 

--- a/cmd/kubectl-conditioner.go
+++ b/cmd/kubectl-conditioner.go
@@ -1,13 +1,30 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/devbytes-cloud/conditioner/pkg/cmd"
 	"github.com/spf13/pflag"
-
 	"k8s.io/cli-runtime/pkg/genericiooptions"
+
+	"github.com/devbytes-cloud/conditioner/pkg/config"
 )
+
+func init() {
+	exists, err := config.Exists()
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	if !exists {
+		if err := config.Write(); err != nil {
+			fmt.Println(err.Error())
+			os.Exit(1)
+		}
+	}
+}
 
 func main() {
 	flags := pflag.NewFlagSet("kubectl-conditioner", pflag.ExitOnError)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/devbytes-cloud/conditioner
 go 1.22.0
 
 require (
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de h1:9TO3cAIGXtEhn
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587 h1:HfkjXDfhgVaN5rmueG8cL8KKeFNecRCXFhaJ2qZ5SKA=
 github.com/moby/term v0.0.0-20221205130635-1aeaba878587/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/cmd/conditioner_test.go
+++ b/pkg/cmd/conditioner_test.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"testing"
 
+	"github.com/devbytes-cloud/conditioner/pkg/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 )
 
@@ -22,7 +23,7 @@ func TestComplete(t *testing.T) {
 	c.Flags().String("message", "kubelet is posting ready status", "")
 	c.Flags().Bool("remove", false, "remove the condition") // Make sure to define the 'remove' flag
 
-	err := o.Complete(c, []string{"test-node"})
+	err := o.Complete(c, []string{"test-node"}, &config.Config{})
 	assert.NoError(t, err)
 
 	// Assert the fields are set correctly

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+// ConfigName is the name of the configuration file.
+const configName string = "~/.conditioner.json"
+
+// Config represents the conditioners configuration.
+// It includes fields for user preferences and settings.
+type Config struct {
+	// WhoAmI indicates whether to prepend the user's identity to the output.
+	WhoAmI bool `json:"prepend-whoami"`
+	// AllowList is a list of allowed entities for the application.
+	AllowList []string `json:"allow-list"`
+}
+
+// Exists checks if the configuration file exists.
+// It returns a boolean indicating the existence of the file and any error encountered.
+func Exists() (bool, error) {
+	path, err := getPath()
+	if err != nil {
+		return false, err
+	}
+
+	if _, err := os.Stat(path); err == nil {
+		return true, nil
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	} else {
+		return false, err
+	}
+}
+
+// Write writes the default configuration to the configuration file.
+// It returns any error encountered during the operation.
+func Write() error {
+	conf := &Config{
+		WhoAmI:    false,
+		AllowList: []string{},
+	}
+
+	confJson, err := json.MarshalIndent(conf, "", "\t")
+	if err != nil {
+		return err
+	}
+
+	fileName, err := getPath()
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(fileName, confJson, 0o644)
+}
+
+// getPath expands the configuration file name to its full path.
+// It returns the full path and any error encountered.
+func getPath() (string, error) {
+	return homedir.Expand(configName)
+}
+
+// Read is a placeholder function for reading the configuration file.
+func Read() (*Config, error) {
+	path, err := getPath()
+	if err != nil {
+		return nil, err
+	}
+
+	byteConfig, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &Config{}
+	if err := json.Unmarshal(byteConfig, config); err != nil {
+		return nil, err
+	}
+	return config, nil
+}


### PR DESCRIPTION
Conditioner will now create a `.conditioner.json` to your home directory.

The json file currently has two tuneables

- prepend-whoami: which will prepend your username to the message
- allow-list: this allows you to define which condition types you only want to use